### PR TITLE
Fixes for issue #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/.project

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ In addition to displaying markers on the control bar, videojs-markers also show 
             'color': 'white',
             'font-size': '18px'
           }
-        }
+        },
+        forceInitialization: true // doesn't wait for loadedmetadata event
       },
       marker_breaks:[9.5, 16, 28, 36],
       marker_text  :['text1','text2','text3','text4']
@@ -105,5 +106,6 @@ Default setting of videojs-markers:
           'color': 'white',
           'font-size': '17px',
         }
-      }
+      },
+      forceInitialization: false
     };

--- a/src/videojs.markers.js
+++ b/src/videojs.markers.js
@@ -26,10 +26,17 @@
             'font-size': '17px'
          }
       },
+      forceInitialization: false
 
 
    };
-
+   
+   function registerVideoJsMarkersPlugin() {
+      // check that videojs is loaded
+      if (!(typeof videojs == 'function')) { 
+         setTimeout(function() { registerVideoJsMarkersPlugin(); }, 100); 
+      } else {
+         
    /**
     * register the markers plugin (dependent on jquery)
     */
@@ -111,7 +118,11 @@
       }
 
       //load the markers
-      this.on("loadedmetadata", function(){
+      function initializeMarkers(){
+         if (player.duration() == 0) {
+            setTimeout(function() { initializeMarkers(); }, 100);
+         } else {
+            
          console.log("[videojs-markers] Initialize");
          createMarkers();
          console.log("[videojs-markers] markers");
@@ -126,6 +137,22 @@
          if(setting.breakOverlay.display){
             displayBreakOverlay();
          }
-      });
+         
+         }
+      }
+      
+      if(setting.forceInitialization){
+         initializeMarkers();
+      } else {
+          this.on("loadedmetadata", function(){
+             initializeMarkers();
+          });
+      }
+      
    });
+   
+   }}
+   
+   registerVideoJsMarkersPlugin();
+   
 })(jQuery);


### PR DESCRIPTION
- Wrapped registration of the marker plugin in a
  registerVideoJsMarkersPlugin method with a check for videojs load and a
  recursive timeout
- Moved the code for initializing markers into its own
  initializeMarkers method with a check for player duration and a
  recursive timeout
- Added a forceInitialization setting which immediately attempts
  initialization if true
- Updated README

Note that indenting was not changed to make the pull request easier to review and there is not currently a limiting timeout in place for the registration or initialization checks.  Both of those could be addressed in a subsequent pull request.
