### PR TITLE
Revert "trigger custom click handler upon marker click"

### DIFF
--- a/src/videojs.markers.js
+++ b/src/videojs.markers.js
@@ -96,10 +96,6 @@
             marker.div.on('click', function(e) {
                var key = $(this).data('marker-index');
                player.currentTime(markers[key].time);
-
-               if (marker.onClick) {
-                  marker.onClick(marker);
-               }
             });
             
             if (setting.markerTip.display) {


### PR DESCRIPTION
Reverts spchuang/videojs-markers#13

One thing i would like to add is instead of marker-specific onclick handler, have a general marker onclick. It could be initiated in the markerTip option. The reason here is the custom onClick logic will most likely be the same for all markers so attaching independent callbacks for each markers don't make so much sense. We could possibly have both options available. 