### PR TITLE
fix main path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "version": "0.5.0",
   "main": [
     "dist/videojs-markers.js",
-    "dist/videojs-markers.css"
+    "dist/videojs.markers.css"
   ],
   "ignore": [
       "src",


### PR DESCRIPTION
There is a typo in the bower.json , causing wiredep to miss the css file.

Could alternatively rename the file. Might also want to have bower.json point at the minified files.