### PR TITLE
Fix auto triggering

### DIFF
--- a/src/videojs.markers.js
+++ b/src/videojs.markers.js
@@ -2,6 +2,9 @@
 'use strict'; 
 
 (function($, videojs, undefined) {
+   //constants 
+   var UPDATE_PERIOD = 0.3; // approx max period of timeupdate event is 250 ms
+
    //default setting
    var defaultSetting = {
       markerStyle: {
@@ -287,7 +290,12 @@
          if (newMarkerIndex != currentMarkerIndex) {
             // trigger event
             if (newMarkerIndex != -1 && options.onMarkerReached) {
-              options.onMarkerReached(markersList[newMarkerIndex]);
+               var nextMarker = markersList[newMarkerIndex];
+               // do not auto trigger when user jumps over marker(s)
+               var triggerAccuracy = UPDATE_PERIOD * player.playbackRate();
+               if (Math.abs(currentTime - setting.markerTip.time(nextMarker)) <= triggerAccuracy) {
+                  options.onMarkerReached(nextMarker);
+               }
             }
             currentMarkerIndex = newMarkerIndex;
          }


### PR DESCRIPTION
Currently when user jumps over marker(s) auto triggering occurs. For example if user jumps from 5th second to 15th and there is a marker on 10th second 'onMarkerReached' event is fired. Pull request fixes this behavior. 'onMarkerReached' event should be triggered only when current video time reaches marker time.