### PR TITLE
Prevent multiple initialize calls

### DIFF
--- a/src/videojs.markers.js
+++ b/src/videojs.markers.js
@@ -336,6 +336,7 @@ type Marker = {
       }
       onTimeUpdate();
       player.on("timeupdate", onTimeUpdate);
+      player.off("loadedmetadata");
     }
 
     // setup the plugin after we loaded video's meta data


### PR DESCRIPTION
player 'loadedmetadata' event can be fired multiple times if user change source 
```player.src({source: 'newSource', type: 'type'})```