### PR TITLE
Update Video.js dependancy to 'video.js'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
       "README.md"
    ],
   "dependencies"  : {
-     "videojs": ">=4.0",
+     "video.js": ">=4.0",
      "jquery": ">=1.10.2"
   },
   "license": "MIT",


### PR DESCRIPTION
Currently, when using 2x video.js plugins they will have different dependencies listed i.e. 'video.js' and 'videojs'.
The knock on effect is that when you use gulp+main-bower-files to gather up all the js files to include in your project it will add video.js more than once.
When this happens it causes videojs plugin errors (as the plugin will be loaded before the second version of videojs)